### PR TITLE
fix: prevent running with no args and print usage info

### DIFF
--- a/spip_statique.sh
+++ b/spip_statique.sh
@@ -9,6 +9,12 @@
 source="$1"
 dest="${2:-}"
 
+# check user input
+if [ -z $source ]; then
+    echo "usage: $0 URL <target directory optionnal>"
+    exit
+fi
+
 # Eventuel repertoire cible en second parametre
 if [[ $dest != "" ]] ; then
 	echo "$source > $dest"


### PR DESCRIPTION
Sans quoi le script lance les étapes de nettoyage sur le dossier en cours, ce qui peut causer quelques problèmes (c'est du vécu ^^).